### PR TITLE
Feat/increase sdk version compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage:
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: '>=2.17.1 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  cloud_firestore: ^4.15.8
+  cloud_firestore: ^4.1.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
This PR increases the sdk version and cloud_firestore version lower bounds.

This is needed as I'm using this lib with an older app and I don't think this breaks any functionality